### PR TITLE
Replace Path with URL for parsing URLs. Add a test

### DIFF
--- a/dep_tools/stac_utils.py
+++ b/dep_tools/stac_utils.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from pathlib import Path
+from urlpath import URL
 from typing import Union
 
 from azure.storage.blob import ContentSettings
@@ -46,7 +46,7 @@ def _get_stac_item(
     remote: bool = True,
     **kwargs,
 ) -> Item:
-    az_prefix = Path("https://deppcpublicstorage.blob.core.windows.net/output")
+    az_prefix = URL("https://deppcpublicstorage.blob.core.windows.net/output")
     blob_url = az_prefix / path if remote else path
     properties = {}
     if "stac_properties" in xr.attrs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ rioxarray = "*"
 stackstac = "*"
 retry = "*"
 tqdm = "*"
+urlpath = "*"
 xarray = "*"
 rio-stac = "^0.8.0"
 odc-stac = {git = "https://github.com/jessjaco/odc-stac.git", rev = "exception-fix"}

--- a/tests/test_get_stac_item.py
+++ b/tests/test_get_stac_item.py
@@ -2,16 +2,21 @@ import rioxarray
 
 from dep_tools.stac_utils import _get_stac_item
 
-from test_namers import testItemPath, item_id, asset_name
+import pytest
 
-test_url = "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_wofs/0-0-2/TV/001/2021/dep_ls_wofs_TV_001_2021_mean.tif"
-test_path = "dep_ls_wofs/0-0-2/TV/001/2021/dep_ls_wofs_TV_001_2021_mean.tif"
-test_xr = rioxarray.open_rasterio(test_url, chunks=True)
-item = _get_stac_item(test_xr, test_path, collection="dep_ls_wofs")
-properties = item.properties
+TEST_ITEM_URL = "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_wofs/0-0-2/TV/001/2021/dep_ls_wofs_TV_001_2021_mean.tif"
 
 
-def test_get_stac_item_properties():
+@pytest.fixture
+def stac_item():
+    test_path = "dep_ls_wofs/0-0-2/TV/001/2021/dep_ls_wofs_TV_001_2021_mean.tif"
+    test_xr = rioxarray.open_rasterio(TEST_ITEM_URL, chunks=True)
+    item = _get_stac_item(test_xr, test_path, collection="dep_ls_wofs")
+    return item
+
+
+def test_get_stac_item_properties(stac_item):
+    properties = stac_item.properties
     keys = [
         "start_datetime",
         "end_datetime",
@@ -25,5 +30,9 @@ def test_get_stac_item_properties():
     assert all([key in properties.keys() for key in keys])
 
 
-def test_get_stac_item_collection_id():
-    assert item.collection_id == "dep_ls_wofs"
+def test_get_stac_item_collection_id(stac_item):
+    assert stac_item.collection_id == "dep_ls_wofs"
+
+
+def test_stac_asset_href_is_valid(stac_item):
+    assert stac_item.assets["asset"].href == TEST_ITEM_URL


### PR DESCRIPTION
Using `pathlib.Path` for parsing URLs drops one of the `/`s in `https://`, see assets here https://deppcpublicstorage.blob.core.windows.net/output/dep_s2_mangroves/0-0-3/FJ/001/2022/dep_s2_mangroves_FJ_001_2022.stac-item.json

Switching to `urlpath` seems simple and sensible.