### PR TITLE
fixed syntax for passing mask args

### DIFF
--- a/dep_tools/landsat_utils.py
+++ b/dep_tools/landsat_utils.py
@@ -5,12 +5,14 @@ import pystac_client
 from odc.algo import erase_bad, mask_cleanup
 from pystac import ItemCollection
 from retry import retry
-from xarray import DataArray
+from xarray import DataArray, Dataset
 
 
 def mask_clouds(
-    xr: DataArray, filters: Iterable[Tuple[str, int]] | None = None, keep_ints: bool = False
-) -> DataArray:
+    xr: DataArray | Dataset,
+    filters: Iterable[Tuple[str, int]] | None = None,
+    keep_ints: bool = False,
+) -> DataArray | Dataset:
     """
     Mask clouds in Landsat data.
 

--- a/dep_tools/processors.py
+++ b/dep_tools/processors.py
@@ -22,18 +22,16 @@ class LandsatProcessor(Processor):
         send_area_to_processor: bool = False,
         scale_and_offset: bool = True,
         mask_clouds: bool = True,
-        dilate_mask: Tuple[int, int] | None = None,
-        keep_ints: bool = False
+        mask_clouds_kwargs: dict = dict(),
     ) -> None:
         super().__init__(send_area_to_processor)
         self.scale_and_offset = scale_and_offset
         self.mask_clouds = mask_clouds
-        self.dilate_mask = dilate_mask
-        self.keep_ints = keep_ints
+        self.mask_kwargs = mask_clouds_kwargs
 
     def process(self, xr: DataArray) -> DataArray:
         if self.mask_clouds:
-            xr = mask_clouds(xr, dilate=self.dilate_mask, keep_ints=True)
+            xr = mask_clouds(xr, **self.mask_kwargs)
         if self.scale_and_offset:
             # These values only work for SR bands of landsat. Ideally we could
             # read from metadata. _Really_ ideally we could just pass "scale"


### PR DESCRIPTION
Args to landsat processor didn't match the new masking args. updated to just use accept kwargs