### PR TITLE
Replace field as default value with empty dict

### DIFF
--- a/dep_tools/writers.py
+++ b/dep_tools/writers.py
@@ -1,15 +1,13 @@
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import field
 from functools import partial
 from typing import Callable, Dict, Hashable, List, Union
 
 import numpy as np
+from azure.storage.blob import ContainerClient
 from pystac import Asset
 from urlpath import URL
 from xarray import DataArray, Dataset
-
-from azure.storage.blob import ContainerClient
 
 from .azure import get_container_client
 from .namers import DepItemPath
@@ -33,7 +31,7 @@ class XrWriterMixin(object):
         output_value_multiplier: int = 10000,
         scale_int16s: bool = False,
         output_nodata: int = -32767,
-        extra_attrs: Dict = field(default_factory=dict),
+        extra_attrs: Dict = {},
     ):
         self.convert_to_int16 = convert_to_int16
         self.output_value_multiplier = output_value_multiplier
@@ -67,7 +65,7 @@ class DsWriter(XrWriterMixin, Writer):
         output_value_multiplier: int = 10000,
         scale_int16s: bool = False,
         output_nodata: int = -32767,
-        extra_attrs: Dict = field(default_factory=dict),
+        extra_attrs: Dict = {},
     ):
         self.itempath = itempath
         self.use_odc_writer = use_odc_writer
@@ -157,7 +155,7 @@ class LocalDsWriter(DsWriter):
         output_value_multiplier: int = 10000,
         scale_int16s: bool = False,
         output_nodata: int = -32767,
-        extra_attrs: Dict = field(default_factory=dict),
+        extra_attrs: Dict = {},
     ):
         super().__init__(
             itempath=itempath,
@@ -188,7 +186,7 @@ class AzureDsWriter(DsWriter):
         output_value_multiplier: int = 10000,
         scale_int16s: bool = False,
         output_nodata: int = -32767,
-        extra_attrs: Dict = field(default_factory=dict),
+        extra_attrs: Dict = {},
     ):
         self.client = get_container_client() if client is None else client
         write_function = partial(write_to_blob_storage, client=client)


### PR DESCRIPTION
Found an issue when using the `LocalDsWriter` where initialising it fails due to the below error.

I don't really know how `field` is supposed to be used, but it doesn't work how we are using it. Happy to fix this PR with a more appropriate fix if there is a better way to do this!


``` python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[14], [line 18](vscode-notebook-cell:?execution_count=14&line=18)
     [10](vscode-notebook-cell:?execution_count=14&line=10) # Set up a writer and write out the files
     [11](vscode-notebook-cell:?execution_count=14&line=11) writer = LocalDsWriter(
     [12](vscode-notebook-cell:?execution_count=14&line=12)     itempath=dep_path,
     [13](vscode-notebook-cell:?execution_count=14&line=13)     output_nodata=0,
   (...)
     [16](vscode-notebook-cell:?execution_count=14&line=16)     convert_to_int16=False
     [17](vscode-notebook-cell:?execution_count=14&line=17) )
---> [18](vscode-notebook-cell:?execution_count=14&line=18) out_files = writer.write(loaded, item_id)

File [~/.local/lib/python3.10/site-packages/dep_tools/writers.py:88](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:88), in DsWriter.write(self, xr, item_id)
     [87](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:87) def write(self, xr: Dataset, item_id: str) -> str | List:
---> [88](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:88)     xr = super().prep(xr)
     [89](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:89)     paths = []
     [90](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:90)     assets = {}

File [~/.local/lib/python3.10/site-packages/dep_tools/writers.py:45](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:45), in XrWriterMixin.prep(self, xr)
     [44](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:44) def prep(self, xr: Union[DataArray, Dataset]):
---> [45](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:45)     xr.attrs.update(self.extra_attrs)
     [46](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:46)     if self.convert_to_int16:
     [47](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:47)         xr = scale_to_int16(
     [48](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:48)             xr,
     [49](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:49)             output_multiplier=self.output_value_multiplier,
     [50](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:50)             output_nodata=self.output_nodata,
     [51](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:51)             scale_int16s=self.scale_int16s,
     [52](https://vscode-remote+ssh-002dremote-002bcoastlines.vscode-resource.vscode-cdn.net/home/ubuntu/dep-geomad/~/.local/lib/python3.10/site-packages/dep_tools/writers.py:52)         )

TypeError: 'Field' object is not iterable
```