### PR TITLE
Use catalog as the variable not the Client

### DIFF
--- a/dep_tools/loaders.py
+++ b/dep_tools/loaders.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-import warnings
 
 from geopandas import GeoDataFrame
 import odc.stac

--- a/tests/test_searchers.py
+++ b/tests/test_searchers.py
@@ -22,7 +22,9 @@ def mspc_catalog():
 
 
 def test_PystacSearcher(area, mspc_catalog):
-    s = PystacSearcher(catalog=mspc_catalog, collections=["landsat-c2-l2"], datetime="2007")
+    s = PystacSearcher(
+        catalog=mspc_catalog, collections=["landsat-c2-l2"], datetime="2007"
+    )
     items = s.search(area)
     assert isinstance(items, ItemCollection)
 

--- a/tests/test_searchers.py
+++ b/tests/test_searchers.py
@@ -1,6 +1,5 @@
 import geopandas as gpd
 from pystac import ItemCollection
-from pystac_client import Client
 import pytest
 from shapely.geometry import box
 
@@ -18,12 +17,12 @@ def area() -> gpd.GeoDataFrame:
 
 
 @pytest.fixture
-def mspc_client():
-    return Client.open("https://planetarycomputer.microsoft.com/api/stac/v1")
+def mspc_catalog():
+    return "https://planetarycomputer.microsoft.com/api/stac/v1"
 
 
-def test_PystacSearcher(area):
-    s = PystacSearcher(collections=["landsat-c2-l2"], datetime="2007")
+def test_PystacSearcher(area, mspc_catalog):
+    s = PystacSearcher(catalog=mspc_catalog, collections=["landsat-c2-l2"], datetime="2007")
     items = s.search(area)
     assert isinstance(items, ItemCollection)
 


### PR DESCRIPTION
Most controversial here is taking a `catalog` string instead of a complete `Client` object.

I just think it makes more sense!