### PR TITLE
Fix to missing NoOutputError, add fix_winding function, re-add client to searcher

### DIFF
--- a/dep_tools/grids.py
+++ b/dep_tools/grids.py
@@ -115,7 +115,6 @@ def grid(
             Otherwise, a GeoDataFrame containing only the portions of each tile
             that intersect the given GeoDataFrame is returned.
     """
-
     if intersect_with is not None:
         if return_type != "GridSpec":
             full_grid = _geoseries(resolution, crs)

--- a/dep_tools/searchers.py
+++ b/dep_tools/searchers.py
@@ -91,7 +91,9 @@ class LandsatPystacSearcher(PystacSearcher):
     query, just use :class:PystacSearcher.
 
     Args:
-        client: A search client.
+        catalog: The URL of a stac catalog. if client is specified, this is
+            ignored.
+        client: A search client. Either this or catalog must be specified.
         raise_empty_collection_error: Whether an EmptyCollectionError exception should
             be returned if no stac items are found.
         search_intersecting_pathrows: Whether to use landsat pathrows which
@@ -110,7 +112,8 @@ class LandsatPystacSearcher(PystacSearcher):
 
     def __init__(
         self,
-        catalog: str = "https://planetarycomputer.microsoft.com/api/stac/v1/",
+        catalog: str | None = None,
+        client: Client | None = None,
         collections: list[str] | None = ["landsat-c2-l2"],
         raise_empty_collection_error: bool = True,
         search_intersecting_pathrows: bool = False,
@@ -121,6 +124,7 @@ class LandsatPystacSearcher(PystacSearcher):
     ):
         super().__init__(
             catalog=catalog,
+            client=client,
             raise_empty_collection_error=raise_empty_collection_error,
             **kwargs,
         )

--- a/dep_tools/searchers.py
+++ b/dep_tools/searchers.py
@@ -76,11 +76,11 @@ class PystacSearcher(Searcher):
             region=area, client=self._client, **self._kwargs
         )
 
-        if len(item_collection) == 0 and self._raise_errors:
-            raise EmptyCollectionError()
-
         fix_bad_epsgs(item_collection)
         item_collection = remove_bad_items(item_collection)
+
+        if len(item_collection) == 0 and self._raise_errors:
+            raise EmptyCollectionError()
 
         return item_collection
 
@@ -155,16 +155,9 @@ class LandsatPystacSearcher(PystacSearcher):
 
         self._kwargs["query"] = query
 
-        if self._search_intersecting_pathrows:
-            self._landsat_pathrows = read_file(
-                "https://d9-wret.s3.us-west-2.amazonaws.com/assets/palladium/production/s3fs-public/atoms/files/WRS2_descending_0.zip"
-            )
-
     def search(self, area: GeoDataFrame):
         search_area = (
-            pathrows_in_area(area, self._landsat_pathrows)
-            if self._search_intersecting_pathrows
-            else area
+            pathrows_in_area(area) if self._search_intersecting_pathrows else area
         )
         try:
             items = super().search(search_area)
@@ -178,5 +171,8 @@ class LandsatPystacSearcher(PystacSearcher):
 
         if self._search_intersecting_pathrows:
             items = items_in_pathrows(items, search_area)
+
+        if len(items) == 0 and self._raise_errors:
+            raise EmptyCollectionError()
 
         return items

--- a/dep_tools/searchers.py
+++ b/dep_tools/searchers.py
@@ -34,7 +34,9 @@ class PystacSearcher(Searcher):
     :func:`dep_tools.utils.search_across_180`.
 
     Args:
-        client: A search client.
+        catalog: The URL of a stac catalog. if client is specified, this is
+            ignored.
+        client: A search client. Either this or catalog must be specified.
         raise_empty_collection_error: Whether an EmptyCollectionError exception
             should be returned if no stac items are found.
         **kwargs: Additional arguments passed to client.search(). For example,
@@ -44,11 +46,20 @@ class PystacSearcher(Searcher):
 
     def __init__(
         self,
-        catalog: str,
+        catalog: str | None = None,
+        client: Client | None = None,
         raise_empty_collection_error: bool = True,
         **kwargs,
     ):
-        self._client = Client.open(catalog)
+        if client and catalog:
+            warnings.warn(
+                "Arguments for both 'client' and 'catalog' passed to PystacSearcher, ignoring catalog"
+            )
+
+        if not (client or catalog):
+            raise ValueError("Must specify either client or catalog")
+
+        self._client = client if client else Client.open(catalog)
         self._raise_errors = raise_empty_collection_error
         self._kwargs = kwargs
 

--- a/tests/test_fix_winding.py
+++ b/tests/test_fix_winding.py
@@ -1,0 +1,8 @@
+from shapely.geometry import Polygon, MultiPolygon
+from dep_tools.utils import fix_winding
+
+
+def test_fix_winding():
+    bad_poly = Polygon(shell=[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]])
+    assert not bad_poly.exterior.is_ccw
+    assert fix_winding(bad_poly).exterior.is_ccw

--- a/tests/test_landsat_mspc_stac_api.py
+++ b/tests/test_landsat_mspc_stac_api.py
@@ -29,6 +29,7 @@ def test_hobart_all(hobart_area):
         exclude_platforms=None,
         only_tier_one=False,
         fall_back_to_tier_two=False,
+        catalog="https://planetarycomputer.microsoft.com/api/stac/v1/",
     )
 
     items = list(searcher.search(hobart_area))
@@ -42,6 +43,7 @@ def test_hobart_tier_one_only(hobart_area):
         exclude_platforms=None,
         only_tier_one=True,
         fall_back_to_tier_two=False,
+        catalog="https://planetarycomputer.microsoft.com/api/stac/v1/",
     )
 
     items = list(searcher.search(hobart_area))
@@ -55,6 +57,7 @@ def test_hobart_tier_exclude_7(hobart_area):
         exclude_platforms=["landsat-7"],
         only_tier_one=False,
         fall_back_to_tier_two=False,
+        catalog="https://planetarycomputer.microsoft.com/api/stac/v1/",
     )
 
     items = list(searcher.search(hobart_area))

--- a/tests/test_landsat_mspc_stac_search_fixes.py
+++ b/tests/test_landsat_mspc_stac_search_fixes.py
@@ -27,7 +27,9 @@ def test_pathrows_in_area(near_antimeridian_area):
 
 def test_search_for_stac_items_with_bad_geoms(near_antimeridian_area):
     searcher = LandsatPystacSearcher(
-        datetime=DATETIME, search_intersecting_pathrows=True
+        datetime=DATETIME,
+        search_intersecting_pathrows=True,
+        catalog="https://planetarycomputer.microsoft.com/api/stac/v1/",
     )
 
     items = searcher.search(near_antimeridian_area)

--- a/tests/test_searchers.py
+++ b/tests/test_searchers.py
@@ -36,7 +36,10 @@ def test_PystacSearcher(area, mspc_catalog):
 
 
 def test_LandsatPystacSearcher_exclude_platforms(area):
-    s = LandsatPystacSearcher(exclude_platforms=["landsat-7"])
+    s = LandsatPystacSearcher(
+        exclude_platforms=["landsat-7"],
+        catalog="https://planetarycomputer.microsoft.com/api/stac/v1/",
+    )
     s.search(area)
 
 


### PR DESCRIPTION
The only thing that modifies the API is adding back an (optional) `client` argument to `PystacSearcher`. I am flexible on the implementation but I need this because I've been hitting some limits of the earth search API and the the recommended fix is to add retries to the search client (see https://github.com/Element84/earth-search/issues/19 and my test workaround here: https://github.com/jessjaco/broken-workflows/blob/main/big_search.py