### PR TITLE
Set default post-processor to None for aws stac task

### DIFF
--- a/dep_tools/task.py
+++ b/dep_tools/task.py
@@ -119,7 +119,7 @@ class AwsStacTask(StacTask):
         searcher: Searcher,
         loader: StacLoader,
         processor: Processor,
-        post_processor: Processor | None = XrPostProcessor(),
+        post_processor: Processor | None = None,
         logger: Logger = getLogger(),
         **kwargs,
     ):


### PR DESCRIPTION
This was very trick to find!

Not a good default, I don't think. Creating a PR, in case I break your stuff... but let's not convert everything to Int as a default, I think?